### PR TITLE
* added simple image parsing with default Markdown syntax

### DIFF
--- a/Text/Markdown.hs
+++ b/Text/Markdown.hs
@@ -210,7 +210,8 @@ phrase =
     bold <|> italic <|> asterisk <|>
     code <|> backtick <|>
     escape <|>
-    githubLink <|> img <|> link <|> leftBracket <|>
+    img <|> exclamationPoint <|>
+    githubLink <|> link <|> leftBracket <|>
     tag <|> lessThan <|>
     normal
   where
@@ -229,7 +230,7 @@ phrase =
         ((toHtml <$> satisfy (inClass "`*_\\")) <|>
          return "\\")
 
-    normal = toHtml <$> takeWhile1 (notInClass "*_`\\[<")
+    normal = toHtml <$> takeWhile1 (notInClass "*_`\\![<")
 
     githubLink = try $ do
         _ <- string "[["
@@ -274,6 +275,7 @@ phrase =
             Just title -> H.img ! HA.src h ! HA.alt a ! HA.title (toValue title)
 
     leftBracket = toHtml <$> takeWhile1 (== '[')
+    exclamationPoint = toHtml <$> takeWhile1 (== '!')
 
     tag = try $ do
         _ <- char '<'

--- a/test/main.hs
+++ b/test/main.hs
@@ -142,7 +142,7 @@ main = hspec $ do
             "<p><img src=\"http://link.to/image.jpg\" alt=\"foo\" title=\"bar\"></p>"
             "![foo](http://link.to/image.jpg \"bar\")"
         it "inside a paragraph" $ check
-            "<p>Hello <img src=\"http://link.to/image.jpg\" alt=\"foo\"> World"
+            "<p>Hello <img src=\"http://link.to/image.jpg\" alt=\"foo\"> World</p>"
             "Hello ![foo](http://link.to/image.jpg) World"
         it "not an image" $ check
             "<p>Not an ![ image</p>"


### PR DESCRIPTION
This implements image embedding with Markdown's default syntax (same as URLs but preceded by an exclamation point) as well as optional image title parsing.  
It does not implement referential images.

~~I didn't dig too deep into this but while writing the simple tests I found that this does not work for inlined image links.~~
