### PR TITLE
Footnotes

### DIFF
--- a/Text/Markdown.hs
+++ b/Text/Markdown.hs
@@ -154,3 +154,11 @@ toHtmlI ms is0
     go (InlineImage url Nothing content) = H.img H.! HA.src (H.toValue url) H.! HA.alt (H.toValue content)
     go (InlineImage url (Just title) content) = H.img H.! HA.src (H.toValue url) H.! HA.alt (H.toValue content) H.! HA.title (H.toValue title)
     go (InlineHtml t) = escape t
+    go (InlineFootnoteRef x) = let ishown = TL.pack (show x)
+                                   (<>) = mappend
+                                in H.a H.! HA.href (H.toValue $ "#footnote-" <> ishown)
+                                       H.! HA.id (H.toValue $ "ref-" <> ishown) $ H.toHtml $ "[" <> ishown <> "]"
+    go (InlineFootnote x) = let ishown = TL.pack (show x)
+                                (<>) = mappend
+                             in H.a H.! HA.href (H.toValue $ "#ref-" <> ishown)
+                                    H.! HA.id (H.toValue $ "footnote-" <> ishown) $ H.toHtml $ "[" <> ishown <> "]"

--- a/test/main.hs
+++ b/test/main.hs
@@ -202,6 +202,13 @@ main = do
                 }
             "<article class=\"someclass\"><p>foo</p><blockquote><p>bar</p></blockquote></article>"
             "@@@ someclass\nfoo\n\n> bar\n@@@"
+    describe "footnotes" $ do
+        it "inline" $
+            check "<p><a href=\"#footnote-1\" id=\"ref-1\">[1]</a>hello</p>"
+                  "{1}hello"
+        it "references" $
+            check "<p><a href=\"#ref-1\" id=\"footnote-1\">[1]</a>hello</p>"
+                  "{^1}hello"
     describe "examples" $ sequence_ examples
     describe "John Gruber's test suite" $ sequence_ gruber
 


### PR DESCRIPTION
Found myself wanting this feature as I was writing a blog post earlier.

``` markdown
Some text with a citation.{1}

***

{^1}Further explanation goes here.
```

It's an inline, not a block, element, which I thought was a lot more flexible. There's nothing preventing the user from swapping `{1}` and `{^1}` and getting the same behavior.
1. Should we prevent people from using `{^x}` in body text?
   - How?
2. Should this be a block element?
