### PR TITLE
Ordered list markers should be followed by a space

### DIFF
--- a/Text/Markdown/Block.hs
+++ b/Text/Markdown/Block.hs
@@ -11,7 +11,7 @@ module Text.Markdown.Block
     ) where
 
 import Prelude
-import Control.Applicative ((<|>))
+import Control.Monad (msum)
 #if MIN_VERSION_conduit(1, 0, 0)
 import Data.Conduit
 #else
@@ -276,10 +276,8 @@ takeTillConsume f =
 
 listStart :: Text -> Maybe (ListType, Text)
 listStart t0
-    | Just t' <- T.stripPrefix "* " t = Just (Unordered, t')
-    | Just t' <- T.stripPrefix "+ " t = Just (Unordered, t')
-    | Just t' <- T.stripPrefix "- " t = Just (Unordered, t')
-    | Just t' <- stripNumber t, Just t'' <- stripSeparator t' = Just (Ordered, t'')
+    | Just t' <- stripUnorderedListSeparator t = Just (Unordered, t')
+    | Just t' <- stripNumber t, Just t'' <- stripOrderedListSeparator t' = Just (Ordered, t'')
     | otherwise = Nothing
   where
     t = T.stripStart t0
@@ -291,8 +289,19 @@ stripNumber x
   where
     (y, z) = T.span isDigit x
 
-stripSeparator :: Text -> Maybe Text
-stripSeparator x = T.stripPrefix ". " x <|> T.stripPrefix ") " x
+stripUnorderedListSeparator :: Text -> Maybe Text
+stripUnorderedListSeparator =
+  stripPrefixChoice ["* ", "*\t", "+ ", "+\t", "- ", "-\t"]
+
+stripOrderedListSeparator :: Text -> Maybe Text
+stripOrderedListSeparator =
+  stripPrefixChoice [". ", ".\t", ") ", ")\t"]
+
+-- | Attempt to strip each of the prefixes in @xs@ from the start of @x@. As
+-- soon as one matches, return the remainder of @x@. Prefixes are tried in
+-- order. If none match, return @Nothing@.
+stripPrefixChoice :: [Text] -> Text -> Maybe Text
+stripPrefixChoice xs x = msum $ map (flip T.stripPrefix x) xs
 
 getIndented :: Monad m => Int -> Conduit Text m Text
 getIndented leader =

--- a/test/Block.hs
+++ b/test/Block.hs
@@ -29,10 +29,17 @@ blockSpecs = do
             "~~~\nfoo\n\nbar\n"
             [BlockPara " ~~~\nfoo", BlockPara "bar"]
     describe "list" $ do
-        it "simple" $ check
-            "* foo\n\n*    bar\n\n"
+        it "simple unordered" $ check
+            "* foo\n\n*    bar\n\n*\t\tqux"
             [ BlockList Unordered (Right [BlockPara "foo"])
             , BlockList Unordered (Right [BlockPara "bar"])
+            , BlockList Unordered (Right [BlockPara "qux"])
+            ]
+        it "simple ordered" $ check
+            "1. foo\n\n3.    bar\n\n17.\t\tqux"
+            [ BlockList Ordered (Right [BlockPara "foo"])
+            , BlockList Ordered (Right [BlockPara "bar"])
+            , BlockList Ordered (Right [BlockPara "qux"])
             ]
         it "nested" $ check
             "* foo\n* \n    1. bar\n    2. baz"


### PR DESCRIPTION
From the Markdown spec:

> List markers must be followed by one or more spaces or a tab.

Previously `markdown` would check for a space after unordered list markers, but not after ordered list markers - ie. "*Foo" would be (correctly) rejected by the list parser, but "1.Foo" would be (incorrectly) accepted. This patch makes `markdown` check for a space consistently.

Note that `markdown` is still not quite spec-compliant, because "*<tab>Foo" and "1.<tab>Foo" would both be rejected, when they should be accepted. However, this patch prevents the particularly annoying case where "6.5 seconds" is interpreted as a singleton list of "5 seconds".
