### PR TITLE
Add Eq instance for Markdown.

### DIFF
--- a/Text/Markdown.hs
+++ b/Text/Markdown.hs
@@ -45,7 +45,7 @@ import Data.String (IsString)
 
 -- | A newtype wrapper providing a @ToHtml@ instance.
 newtype Markdown = Markdown TL.Text
-  deriving(Monoid, IsString)
+  deriving(Eq, Monoid, IsString)
 
 instance ToMarkup Markdown where
     toMarkup (Markdown t) = markdown def t


### PR DESCRIPTION
As far as I know, this doesn't introduce any overhead. Additionally, it's convenient for when one is too lazy to write a proper `Eq` instance.
