### PR TITLE
Adds the option to include an ID attribute on headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/
 *.swp
 /tarballs/
+.cabal-sandbox/
+cabal.sandbox.config

--- a/Text/Markdown/Types.hs
+++ b/Text/Markdown/Types.hs
@@ -88,6 +88,19 @@ data MarkdownSettings = MarkdownSettings
       -- Default: @id@
       --
       -- Since 0.1.7
+
+    , msAddHeadingId :: Bool
+      -- ^ If @True@, an `id` attribute is added to the heading tag with the value equal to
+      -- the text with only valid CSS identifier characters.
+      --
+      -- > ## Executive Summary
+      --
+      -- > <h2 id="executive-summary">Executive Summary</h2>
+      --
+      -- Default: @False@
+      --
+      -- Since 0.1.13
+
     }
 
 -- | See 'msFencedHandlers.
@@ -110,6 +123,7 @@ instance Default MarkdownSettings where
         , msLinkNewTab = False
         , msBlankBeforeBlockquote = True
         , msBlockFilter = id
+        , msAddHeadingId = False
         }
 
 -- | Helper for creating a 'FHRaw'.

--- a/markdown.cabal
+++ b/markdown.cabal
@@ -1,5 +1,5 @@
 Name:                markdown
-Version:             0.1.12
+Version:             0.1.13
 Synopsis:            Convert Markdown to HTML, with XSS protection
 Description:         This library leverages existing high-performance libraries (attoparsec, blaze-html, text, and conduit), and should integrate well with existing codebases.
 Homepage:            https://github.com/snoyberg/markdown
@@ -21,6 +21,7 @@ Library
                        Text.Markdown.Inline
   other-modules:       Text.Markdown.Types
   Build-depends:       base                   >= 4       && < 5
+                     , blaze-markup           >= 0.6
                      , blaze-html             >= 0.4
                      , attoparsec             >= 0.10
                      , transformers           >= 0.2.2

--- a/test/main.hs
+++ b/test/main.hs
@@ -146,6 +146,20 @@ main = do
             $ check
                 "<h1>foo</h1><h2>bar</h2>"
                 "foo\n=============\n\nbar\n----------------\n"
+    describe "headings with ID" $ do
+        let withHeadingId = def { msAddHeadingId = True }
+        it "without spaces"
+            $ checkSet withHeadingId
+                "<h1 id=\"foo\">foo</h1><h2 id=\"bar\">bar</h2><h3 id=\"baz\">baz</h3>"
+                "# foo\n\n##     bar\n\n###baz"
+        it "with spaces"
+            $ checkSet withHeadingId
+                "<h1 id=\"executive-summary\">Executive summary</h1>"
+                "# Executive summary"
+        it "with special characters"
+            $ checkSet withHeadingId
+                "<h1 id=\"executive-summary-.-_:\">Executive summary .!@#$%^*()-_=:</h1>"
+                "# Executive summary .!@#$%^*()-_=:"
     describe "blockquotes" $ do
         it "simple"
             $ check
@@ -181,7 +195,7 @@ main = do
     -}
 
     describe "images" $ do
-        it "simple" $ check 
+        it "simple" $ check
             "<p><img src=\"http://link.to/image.jpg\" alt=\"foo\"></p>"
             "![foo](http://link.to/image.jpg)"
         it "title" $ check


### PR DESCRIPTION
I'm not sure this belongs in `markdown` or not. 

The use case of enabling `msAddHeadingId` is for generating URLs that can jump directly to a heading.

For example, given a document that may look like this:

```
# My Report
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis eleifend in dui sed interdum. Sed eget sapien sit amet nibh lacinia tristique. Proin malesuada, ipsum nec congue commodo, metus nulla sagittis arcu, sit amet interdum urna libero nec nunc.

## Introduction
In in consequat lacus. Sed quis ipsum non mi ultricies volutpat in id enim. Quisque non imperdiet nunc, ut rhoncus odio. Fusce ipsum est, ultrices non libero in, ornare ultricies mauris. 

## Summary
Phasellus mattis ultrices erat in ultrices. Nunc eget accumsan eros, sed placerat dui. Vestibulum congue scelerisque mauris sed fringilla. Vestibulum mollis vitae felis sed volutpat. Morbi sollicitudin venenatis vulputate.
```

The generated HTML for `## Summary` would be

```
<h2 id="summary">Summary</h2>
```

Now, I can jump directly to the Summary by using the `http://mywebsite.com/#summary` URL.

Comments or suggestions welcomed.
